### PR TITLE
fixes deprecation warnings for 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.4
+    - 0.5
 notifications:
     email: false

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -286,7 +286,7 @@ function element(st, evr, dcm)
     sz = read(st,lentype)
 
     data =
-    vr=="ST" || vr=="LT" || vr=="UT" ? bytestring(read(st, UInt8, sz)) :
+    vr=="ST" || vr=="LT" || vr=="UT" ? string(read(st, UInt8, sz)) :
 
     sz==0 || vr=="XX" ? Any[] :
 


### PR DESCRIPTION
Your PR will make DICOM.jl work on v0.5+, this one line change will fix the last of the deprecation warnings.